### PR TITLE
feat: generalize extension to allow for other resources outside an MCP

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -36,13 +36,13 @@ jobs:
         run: pnpm demo
 
       - name: 📄 Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
 
       - name: 📤 Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: './demo/dist'
 
       - name: 🚀 Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4

--- a/demo/index.html
+++ b/demo/index.html
@@ -36,6 +36,15 @@
         <div id="prompts" class="min-h-[50px]"></div>
         <p class="text-gray-500 text-sm">Type <code>/</code> to show prompts</p>
       </div>
+
+      <h2 class="text-2xl font-bold mb-4">Demo without MCP extension (using primitives)</h2>
+      <div class="border rounded-lg p-4 bg-white shadow-sm">
+        <div id="primitives-editor" class="min-h-[200px]"></div>
+        <p class="text-gray-500 text-sm">
+          This editor uses lower-level primitives: resource completion, hover tooltips, and markdown syntax highlighting
+          without the full MCP extension. Type <code>@</code> to see resource completions.
+        </p>
+      </div>
     </main>
     <script type="module" src="./index.ts"></script>
   </body>

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -1,3 +1,4 @@
+import { autocompletion } from "@codemirror/autocomplete";
 import { markdown } from "@codemirror/lang-markdown";
 import { tooltips } from "@codemirror/view";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
@@ -9,8 +10,17 @@ import type {
 	PromptMessage,
 } from "@modelcontextprotocol/sdk/types.js";
 import { EditorView, basicSetup } from "codemirror";
-import { extractResources } from "../src";
+import {
+	extractResources,
+	hoverResource,
+	resourceCompletion,
+	resourceInputFilter,
+	resourceTheme,
+	resourcesField,
+} from "../src";
+import type { Resource } from "../src";
 import { mcpExtension } from "../src/mcp";
+import { resourceDecorations } from "../src/resources/decoration";
 
 class DemoTransport implements Transport {
 	mockPrompts = [
@@ -217,5 +227,125 @@ ${formattedResources}
 	document.querySelector("#editor")?.parentElement?.appendChild(button);
 	document.querySelector("#editor")?.parentElement?.appendChild(prompt);
 
-	return { editor, promptEditor };
+	// Create a demo using lower-level primitives without MCP extension
+	const mockResources: Resource[] = [
+		{
+			name: "userGuide",
+			uri: "file://docs/user-guide.md",
+			mimeType: "text/markdown",
+			description: "Complete user guide with examples and best practices",
+			type: "file",
+			data: {},
+		},
+		{
+			name: "apiDocs",
+			uri: "file://docs/api.md",
+			mimeType: "text/markdown",
+			description: "API reference documentation",
+			type: "file",
+			data: {},
+		},
+		{
+			name: "config",
+			uri: "var://app/config",
+			mimeType: "application/json",
+			description: "Application configuration object",
+			type: "variable",
+			data: {},
+		},
+		{
+			name: "processData",
+			uri: "function://utils/processData",
+			mimeType: "application/javascript",
+			description: "Processes user input data and returns formatted results",
+			type: "function",
+			data: {},
+		},
+	];
+
+	const markdownLanguage = markdown();
+
+	// Create extensions using primitives
+	const primitivesExtensions = [
+		basicSetup,
+		markdownLanguage,
+		resourcesField,
+		resourceDecorations,
+		resourceInputFilter,
+		autocompletion({
+			override: [
+				resourceCompletion(
+					async () => mockResources,
+					// Custom formatter for completions
+					(resource) => ({
+						detail: `${resource.mimeType || "unknown"} - ${resource.uri}`,
+						boost: resource.description ? 90 : 50,
+					}),
+				),
+			],
+		}),
+		hoverResource({
+			createTooltip: (resource) => {
+				const dom = document.createElement("div");
+				dom.className = "cm-tooltip-cursor cm-tooltip-below";
+				dom.style.padding = "8px";
+				dom.style.backgroundColor = "#f8f9fa";
+				dom.style.border = "1px solid #dee2e6";
+				dom.style.borderRadius = "4px";
+				dom.style.maxWidth = "300px";
+
+				const title = document.createElement("strong");
+				title.textContent = resource.name;
+				title.style.color = "#495057";
+				dom.appendChild(title);
+
+				const uri = document.createElement("div");
+				uri.style.fontSize = "0.85em";
+				uri.style.color = "#6c757d";
+				uri.style.fontFamily = "monospace";
+				uri.textContent = resource.uri;
+				dom.appendChild(uri);
+
+				if (resource.description) {
+					const desc = document.createElement("div");
+					desc.style.marginTop = "6px";
+					desc.style.fontSize = "0.9em";
+					desc.textContent = resource.description;
+					dom.appendChild(desc);
+				}
+
+				if (resource.mimeType) {
+					const mime = document.createElement("div");
+					mime.style.marginTop = "4px";
+					mime.style.fontSize = "0.8em";
+					mime.style.color = "#868e96";
+					mime.textContent = `Type: ${resource.mimeType}`;
+					dom.appendChild(mime);
+				}
+
+				return { dom };
+			},
+		}),
+		resourceTheme,
+		tooltips(),
+	];
+
+	const primitivesEditor = new EditorView({
+		doc: `# Primitives Demo
+
+This editor demonstrates using the lower-level exported primitives:
+- \`resourceCompletion\` for autocomplete functionality
+- \`hoverResource\` for hover tooltips
+- \`resourcesField\` for state management
+- \`resourceTheme\` for styling
+- Standard CodeMirror markdown support
+
+Try typing @ to see resource completions, then hover over the inserted resources:
+
+@`,
+		extensions: primitivesExtensions,
+		parent: document.querySelector("#primitives-editor") ?? undefined,
+	});
+
+	return { editor, promptEditor, primitivesEditor };
 })();

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -9,7 +9,8 @@ import type {
 	PromptMessage,
 } from "@modelcontextprotocol/sdk/types.js";
 import { EditorView, basicSetup } from "codemirror";
-import { extractResources, mcpExtension } from "../src/mcp";
+import { extractResources } from "../src";
+import { mcpExtension } from "../src/mcp";
 
 class DemoTransport implements Transport {
 	mockPrompts = [
@@ -196,7 +197,7 @@ Try typing @ to see MCP completions!
 		const formattedResources = resources
 			.map(
 				({ resource }) =>
-					`${resource.uri} (${resource.type}): ${resource.description || resource.name}`,
+					`<resource>${resource.uri} (${resource.type}): ${resource.description || resource.name}</resource>`,
 			)
 			.join("\n");
 
@@ -204,7 +205,9 @@ Try typing @ to see MCP completions!
 			prompt.textContent = "No resources found";
 		} else {
 			prompt.textContent = `
+<doc>
 ${editor.state.doc.toString()}
+</doc>
 
 Resources:
 ${formattedResources}

--- a/src/__tests__/completion.test.ts
+++ b/src/__tests__/completion.test.ts
@@ -1,0 +1,329 @@
+import { describe, expect, it, vi } from "vitest";
+import { EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { resourceCompletion } from "../resources/completion.js";
+import { resourcesField } from "../state.js";
+import { Resource } from "../resources/resource.js";
+
+const createMockResource = (uri: string, name?: string): Resource => ({
+	uri,
+	name: name || uri,
+	description: `Test resource: ${uri}`,
+	mimeType: "text/plain",
+	data: undefined,
+});
+
+const createMockView = (doc: string, pos: number) => {
+	const state = EditorState.create({
+		doc,
+		extensions: [resourcesField],
+	});
+
+	return new EditorView({
+		state,
+		parent: document.createElement("div"),
+	});
+};
+
+const createMockContext = (text: string, pos: number, explicit = false) => {
+	const view = createMockView(text, pos);
+	
+	return {
+		state: view.state,
+		pos,
+		explicit,
+		view,
+		matchBefore: (regex: RegExp) => {
+			const textBefore = text.slice(0, pos);
+			const match = textBefore.match(regex);
+			if (!match) return null;
+			
+			return {
+				from: pos - match[0].length,
+				to: pos,
+				text: match[0],
+			};
+		},
+		aborted: false,
+		tokenBefore: (types: any) => null,
+		prefix: (text: string, from: number) => text.slice(from, pos),
+	};
+};
+
+describe("resourceCompletion", () => {
+	describe("basic functionality", () => {
+		it("should return null when no @ character is present", async () => {
+			const getResources = vi.fn().mockResolvedValue([]);
+			const completion = resourceCompletion(getResources);
+			
+			const context = createMockContext("hello world", 11);
+			const result = await completion(context);
+			
+			expect(result).toBeNull();
+			expect(getResources).not.toHaveBeenCalled();
+		});
+
+		it("should return null when @ is at cursor position and not explicit", async () => {
+			const getResources = vi.fn().mockResolvedValue([]);
+			const completion = resourceCompletion(getResources);
+			
+			const context = createMockContext("hello @", 7, false);
+			const result = await completion(context);
+			
+			expect(result).toBeNull();
+		});
+
+		it("should return completions when @ is at cursor position and explicit", async () => {
+			const resources = [createMockResource("file.txt")];
+			const getResources = vi.fn().mockResolvedValue(resources);
+			const completion = resourceCompletion(getResources);
+			
+			const context = createMockContext("hello @", 7, true);
+			const result = await completion(context);
+			
+			expect(result).not.toBeNull();
+			expect(result?.options).toHaveLength(1);
+			expect(result?.options[0].label).toBe("@file.txt");
+		});
+
+		it("should return completions when typing after @", async () => {
+			const resources = [createMockResource("file.txt")];
+			const getResources = vi.fn().mockResolvedValue(resources);
+			const completion = resourceCompletion(getResources);
+			
+			const context = createMockContext("hello @fi", 9);
+			const result = await completion(context);
+			
+			expect(result).not.toBeNull();
+			expect(result?.options).toHaveLength(1);
+			expect(result?.from).toBe(6); // Start of @fi
+		});
+
+		it("should return null when no resources are available", async () => {
+			const getResources = vi.fn().mockResolvedValue([]);
+			const completion = resourceCompletion(getResources);
+			
+			const context = createMockContext("hello @file", 11);
+			const result = await completion(context);
+			
+			expect(result).toBeNull();
+		});
+	});
+
+	describe("completion options", () => {
+		it("should create completion options with correct properties", async () => {
+			const resources = [
+				createMockResource("file.txt", "My File"),
+				createMockResource("doc.md", "Documentation"),
+			];
+			const getResources = vi.fn().mockResolvedValue(resources);
+			const completion = resourceCompletion(getResources);
+			
+			const context = createMockContext("@", 1, true);
+			const result = await completion(context);
+			
+			expect(result?.options).toHaveLength(2);
+			
+			const option1 = result?.options[0];
+			expect(option1?.label).toBe("@My File");
+			expect(option1?.displayLabel).toBe("My File");
+			expect(option1?.detail).toBe("file.txt");
+			expect(option1?.info).toBe("Test resource: file.txt");
+			expect(option1?.type).toBe("constant");
+			expect(option1?.boost).toBe(100);
+		});
+
+		it("should handle resources without description", async () => {
+			const resource: Resource = {
+				uri: "file.txt",
+				name: "file.txt",
+				description: undefined,
+				mimeType: "text/plain",
+				data: undefined,
+			};
+			const getResources = vi.fn().mockResolvedValue([resource]);
+			const completion = resourceCompletion(getResources);
+			
+			const context = createMockContext("@", 1, true);
+			const result = await completion(context);
+			
+			const option = result?.options[0];
+			expect(option?.info).toBeUndefined();
+			expect(option?.boost).toBe(0);
+		});
+
+		it("should handle resources without mimeType", async () => {
+			const resource: Resource = {
+				uri: "file.txt",
+				name: "file.txt",
+				description: "A file",
+				mimeType: undefined,
+				data: undefined,
+			};
+			const getResources = vi.fn().mockResolvedValue([resource]);
+			const completion = resourceCompletion(getResources);
+			
+			const context = createMockContext("@", 1, true);
+			const result = await completion(context);
+			
+			const option = result?.options[0];
+			expect(option?.type).toBe("variable");
+		});
+
+		it("should use custom formatter when provided", async () => {
+			const resources = [createMockResource("file.txt")];
+			const getResources = vi.fn().mockResolvedValue(resources);
+			const formatResource = vi.fn().mockReturnValue({
+				label: "Custom Label",
+				type: "custom",
+				boost: 999,
+			});
+			const completion = resourceCompletion(getResources, formatResource);
+			
+			const context = createMockContext("@", 1, true);
+			const result = await completion(context);
+			
+			const option = result?.options[0];
+			expect(option?.label).toBe("Custom Label");
+			expect(option?.type).toBe("custom");
+			expect(option?.boost).toBe(999);
+			expect(formatResource).toHaveBeenCalledWith(resources[0]);
+		});
+	});
+
+	describe("apply functionality", () => {
+		it("should insert resource URI with space when applied", async () => {
+			const resources = [createMockResource("file.txt")];
+			const getResources = vi.fn().mockResolvedValue(resources);
+			const completion = resourceCompletion(getResources);
+			
+			const context = createMockContext("@fi", 3);
+			const result = await completion(context);
+			
+			const option = result?.options[0];
+			expect(option?.apply).toBeDefined();
+
+			// Mock the apply function
+			const mockView = {
+				dispatch: vi.fn(),
+			};
+
+			if (option?.apply && typeof option.apply === "function") {
+				option.apply(mockView as any, option, 0, 3);
+				
+				expect(mockView.dispatch).toHaveBeenCalledWith({
+					changes: { from: 0, to: 3, insert: "@file.txt " },
+				});
+			}
+		});
+	});
+
+	describe("state updates", () => {
+		it("should dispatch updateResources effect when view is available", async () => {
+			const resources = [createMockResource("file.txt")];
+			const getResources = vi.fn().mockResolvedValue(resources);
+			const completion = resourceCompletion(getResources);
+			
+			const view = createMockView("@", 1);
+			const dispatchSpy = vi.spyOn(view, "dispatch");
+			
+			const context = {
+				...createMockContext("@", 1, true),
+				view,
+			};
+			
+			await completion(context);
+			
+			expect(dispatchSpy).toHaveBeenCalledWith({
+				effects: expect.anything(),
+			});
+		});
+
+		it("should not dispatch when view is not available", async () => {
+			const resources = [createMockResource("file.txt")];
+			const getResources = vi.fn().mockResolvedValue(resources);
+			const completion = resourceCompletion(getResources);
+			
+			const context = {
+				...createMockContext("@", 1, true),
+				view: undefined,
+			};
+			
+			const result = await completion(context);
+			
+			// Should still return completions even without view
+			expect(result?.options).toHaveLength(1);
+		});
+	});
+
+	describe("pattern matching", () => {
+		it("should match @ at start of word", async () => {
+			const resources = [createMockResource("file.txt")];
+			const getResources = vi.fn().mockResolvedValue(resources);
+			const completion = resourceCompletion(getResources);
+			
+			const context = createMockContext("@file", 5);
+			const result = await completion(context);
+			
+			expect(result).not.toBeNull();
+			expect(result?.from).toBe(0);
+		});
+
+		it("should match @ in middle of text", async () => {
+			const resources = [createMockResource("file.txt")];
+			const getResources = vi.fn().mockResolvedValue(resources);
+			const completion = resourceCompletion(getResources);
+			
+			const context = createMockContext("hello @file", 11);
+			const result = await completion(context);
+			
+			expect(result).not.toBeNull();
+			expect(result?.from).toBe(6);
+		});
+
+		it("should match @ with partial word characters", async () => {
+			const resources = [createMockResource("file123.txt")];
+			const getResources = vi.fn().mockResolvedValue(resources);
+			const completion = resourceCompletion(getResources);
+			
+			const context = createMockContext("@file123", 8);
+			const result = await completion(context);
+			
+			expect(result).not.toBeNull();
+		});
+
+		it("should not match @ followed by non-word characters", async () => {
+			const getResources = vi.fn().mockResolvedValue([]);
+			const completion = resourceCompletion(getResources);
+			
+			const context = createMockContext("@-file", 6);
+			const result = await completion(context);
+			
+			expect(result).toBeNull();
+		});
+	});
+
+	describe("error handling", () => {
+		it("should handle getResources errors gracefully", async () => {
+			const getResources = vi.fn().mockRejectedValue(new Error("Failed to fetch"));
+			const completion = resourceCompletion(getResources);
+			
+			const context = createMockContext("@file", 5);
+			
+			await expect(completion(context)).rejects.toThrow("Failed to fetch");
+		});
+
+		it("should handle malformed resources", async () => {
+			const malformedResource = { uri: "test" } as Resource;
+			const getResources = vi.fn().mockResolvedValue([malformedResource]);
+			const completion = resourceCompletion(getResources);
+			
+			const context = createMockContext("@", 1, true);
+			const result = await completion(context);
+			
+			// Should handle gracefully and still create completion
+			expect(result?.options).toHaveLength(1);
+			expect(result?.options[0].label).toBe("@undefined"); // name is undefined
+		});
+	});
+});

--- a/src/__tests__/decoration.test.ts
+++ b/src/__tests__/decoration.test.ts
@@ -2,11 +2,11 @@ import { EditorState, Extension } from "@codemirror/state";
 import type { RangeSet } from "@codemirror/state";
 import type { Decoration } from "@codemirror/view";
 import { EditorView } from "@codemirror/view";
-import type { Resource } from "@modelcontextprotocol/sdk/types.js";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import { resourceDecorations } from "../decoration";
-import { mcpOptionsField, resourcesField, updateResources } from "../state";
-import { invariant } from "../utils";
+import { resourceDecorations } from "../resources/decoration.js";
+import type { Resource } from "../resources/resource.js";
+import { mcpOptionsField, resourcesField, updateResources } from "../state.js";
+import { invariant } from "../utils.js";
 
 // Helper function to count decorations
 function countDecorations(decos: RangeSet<Decoration>): number {
@@ -20,8 +20,8 @@ function countDecorations(decos: RangeSet<Decoration>): number {
 describe("resourceDecorations", () => {
 	let view: EditorView;
 	const sampleResources: Resource[] = [
-		{ name: "repo1", uri: "github://repo1", type: "github" },
-		{ name: "repo2", uri: "gitlab://repo2", type: "gitlab" },
+		{ name: "repo1", uri: "github://repo1", type: "github", data: {} },
+		{ name: "repo2", uri: "gitlab://repo2", type: "gitlab", data: {} },
 	];
 
 	beforeEach(() => {
@@ -132,6 +132,7 @@ describe("resourceDecorations", () => {
 				name: "repo3",
 				uri: "github://repo3",
 				type: "github",
+				data: {},
 			},
 		];
 

--- a/src/__tests__/hover.test.ts
+++ b/src/__tests__/hover.test.ts
@@ -1,7 +1,7 @@
-import type { Resource } from "@modelcontextprotocol/sdk/types.js";
 import { describe, expect, test } from "vitest";
-import { type ResourceMatch, createTooltip, findResourceAtPosition } from "../hover";
-import { invariant } from "../utils";
+import { createDefaultTooltip, findResourceAtPosition } from "../resources/hover.js";
+import type { Resource } from "../resources/resource.js";
+import { invariant } from "../utils.js";
 
 describe("hover", () => {
 	const sampleResources = new Map<string, Resource>([
@@ -13,6 +13,7 @@ describe("hover", () => {
 				type: "github",
 				description: "A sample repository",
 				mimeType: "application/x-git",
+				data: {},
 			},
 		],
 		[
@@ -21,6 +22,7 @@ describe("hover", () => {
 				name: "repo2",
 				uri: "gitlab://repo2",
 				type: "gitlab",
+				data: {},
 			},
 		],
 	]);
@@ -83,7 +85,7 @@ describe("hover", () => {
 		test("should create tooltip with resource info", () => {
 			const resource = sampleResources.get("github://repo1");
 			invariant(resource !== undefined, "Resource not found");
-			const tooltip = createTooltip(resource);
+			const tooltip = createDefaultTooltip(resource);
 
 			expect(tooltip.dom).toBeDefined();
 			expect(tooltip.dom.className).toBe("cm-tooltip-cursor");
@@ -104,7 +106,7 @@ describe("hover", () => {
 		test("should handle missing optional fields", () => {
 			const resource = sampleResources.get("gitlab://repo2");
 			invariant(resource !== undefined, "Resource not found");
-			const tooltip = createTooltip(resource);
+			const tooltip = createDefaultTooltip(resource);
 
 			const title = tooltip.dom.querySelector(".cm-tooltip-cursor-title");
 			expect(title).toBeDefined();
@@ -125,6 +127,7 @@ describe("hover", () => {
 					type: "github",
 					description: "A GitHub repository",
 					mimeType: "application/x-git",
+					data: {},
 				},
 				{
 					name: "ticket1",
@@ -132,6 +135,7 @@ describe("hover", () => {
 					type: "jira",
 					description: "A Jira ticket",
 					mimeType: "application/json",
+					data: {},
 				},
 				{
 					name: "page1",
@@ -139,11 +143,12 @@ describe("hover", () => {
 					type: "notion",
 					description: "A Notion page",
 					mimeType: "text/html",
+					data: {},
 				},
 			];
 
 			for (const resource of resources) {
-				const tooltip = createTooltip(resource);
+				const tooltip = createDefaultTooltip(resource);
 				const title = tooltip.dom.querySelector(".cm-tooltip-cursor-title");
 				const description = tooltip.dom.querySelector(".cm-tooltip-cursor-description");
 				const mimeType = tooltip.dom.querySelector(".cm-tooltip-cursor-mimetype");

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -6,8 +6,13 @@ describe("index.ts exports", () => {
 		const sortedExports = Object.keys(exports).sort();
 		expect(sortedExports).toMatchInlineSnapshot(`
 			[
+			  "createDefaultTooltip",
 			  "extractResources",
+			  "hoverResource",
 			  "mcpExtension",
+			  "resourceCompletion",
+			  "resourceTheme",
+			  "resourcesField",
 			]
 		`);
 	});

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -11,6 +11,7 @@ describe("index.ts exports", () => {
 			  "hoverResource",
 			  "mcpExtension",
 			  "resourceCompletion",
+			  "resourceKeymap",
 			  "resourceTheme",
 			  "resourcesField",
 			]

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -11,7 +11,7 @@ describe("index.ts exports", () => {
 			  "hoverResource",
 			  "mcpExtension",
 			  "resourceCompletion",
-			  "resourceKeymap",
+			  "resourceInputFilter",
 			  "resourceTheme",
 			  "resourcesField",
 			]

--- a/src/__tests__/input-filter.test.ts
+++ b/src/__tests__/input-filter.test.ts
@@ -1,0 +1,115 @@
+import { EditorState, Transaction } from "@codemirror/state";
+import { describe, expect, it } from "vitest";
+import { resourceInputFilter } from "../resources/input-filter.js";
+import { resourcesField } from "../state.js";
+
+describe("resourceInputFilter", () => {
+	describe("filter creation and basic behavior", () => {
+		it("should create a transaction filter", () => {
+			expect(resourceInputFilter).toBeDefined();
+			expect(typeof resourceInputFilter).toBe("object");
+		});
+	});
+
+	describe("basic transaction filtering", () => {
+		it("should handle basic text insertion", () => {
+			const state = EditorState.create({
+				doc: "hello world",
+				extensions: [resourcesField, resourceInputFilter],
+			});
+
+			const tr = state.update({
+				changes: { from: 5, to: 5, insert: " there" },
+				annotations: [Transaction.userEvent.of("input.type")],
+			});
+
+			expect(tr.newDoc.toString()).toBe("hello there world");
+		});
+
+		it("should preserve document content for non-input transactions", () => {
+			const state = EditorState.create({
+				doc: "test content",
+				extensions: [resourcesField, resourceInputFilter],
+			});
+
+			const tr = state.update({
+				changes: { from: 0, to: 4, insert: "new" },
+			});
+
+			expect(tr.newDoc.toString()).toBe("new content");
+		});
+
+		it("should handle empty documents", () => {
+			const state = EditorState.create({
+				doc: "",
+				extensions: [resourcesField, resourceInputFilter],
+			});
+
+			const tr = state.update({
+				changes: { from: 0, to: 0, insert: "test" },
+			});
+
+			expect(tr.newDoc.toString()).toBe("test");
+		});
+
+		it("should handle cursor-only changes", () => {
+			const state = EditorState.create({
+				doc: "hello world",
+				extensions: [resourcesField, resourceInputFilter],
+			});
+
+			const tr = state.update({
+				selection: { anchor: 5, head: 5 },
+			});
+
+			expect(tr.newDoc.toString()).toBe("hello world");
+			expect(tr.selection?.main.anchor).toBe(5);
+		});
+	});
+
+	describe("edge cases", () => {
+		it("should handle multiple simultaneous changes", () => {
+			const state = EditorState.create({
+				doc: "hello world",
+				extensions: [resourcesField, resourceInputFilter],
+			});
+
+			const tr = state.update({
+				changes: [
+					{ from: 0, to: 5, insert: "hi" },
+					{ from: 6, to: 11, insert: "there" },
+				],
+			});
+
+			expect(tr.newDoc.toString()).toBe("hi there");
+		});
+
+		it("should preserve selection state", () => {
+			const state = EditorState.create({
+				doc: "hello world",
+				extensions: [resourcesField, resourceInputFilter],
+				selection: { anchor: 0, head: 5 },
+			});
+
+			const tr = state.update({
+				changes: { from: 11, to: 11, insert: "!" },
+			});
+
+			expect(tr.newDoc.toString()).toBe("hello world!");
+		});
+
+		it("should handle large documents", () => {
+			const largeDoc = "a".repeat(10000);
+			const state = EditorState.create({
+				doc: largeDoc,
+				extensions: [resourcesField, resourceInputFilter],
+			});
+
+			const tr = state.update({
+				changes: { from: 5000, to: 5000, insert: "test" },
+			});
+
+			expect(tr.newDoc.length).toBe(10004);
+		});
+	});
+});

--- a/src/__tests__/mcp-provider.test.ts
+++ b/src/__tests__/mcp-provider.test.ts
@@ -1,0 +1,325 @@
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MCPResourceProvider } from "../mcp/mcp-provider.js";
+
+// Mock the MCP SDK
+vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
+	Client: vi.fn().mockImplementation(() => ({
+		connect: vi.fn().mockResolvedValue(undefined),
+		request: vi.fn(),
+	})),
+}));
+
+const createMockTransport = (): Transport => ({
+	start: vi.fn().mockResolvedValue(undefined),
+	close: vi.fn().mockResolvedValue(undefined),
+	send: vi.fn().mockResolvedValue(undefined),
+	onmessage: undefined,
+	onerror: undefined,
+	onclose: undefined,
+});
+
+const createMockLogger = () =>
+	({
+		log: vi.fn(),
+		error: vi.fn(),
+		warn: vi.fn(),
+		info: vi.fn(),
+	}) as unknown as typeof console;
+
+describe("MCPResourceProvider", () => {
+	let mockTransport: Transport;
+	let mockLogger: typeof console;
+
+	beforeEach(() => {
+		mockTransport = createMockTransport();
+		mockLogger = createMockLogger();
+		vi.clearAllMocks();
+	});
+
+	describe("constructor", () => {
+		it("should create provider with default client options", () => {
+			const provider = new MCPResourceProvider(mockTransport);
+			expect(provider).toBeDefined();
+		});
+
+		it("should create provider with custom client options", () => {
+			const provider = new MCPResourceProvider(
+				mockTransport,
+				{ name: "custom-client", version: "1.0.0" },
+				mockLogger,
+			);
+			expect(provider).toBeDefined();
+		});
+
+		it("should create provider with logger", () => {
+			const provider = new MCPResourceProvider(mockTransport, undefined, mockLogger);
+			expect(provider).toBeDefined();
+		});
+	});
+
+	describe("getResources", () => {
+		it("should throw error when client is not connected", async () => {
+			const { Client } = await import("@modelcontextprotocol/sdk/client/index.js");
+			const mockClient = {
+				connect: vi.fn().mockRejectedValue(new Error("Connection failed")),
+				request: vi.fn(),
+			};
+			vi.mocked(Client).mockReturnValue(mockClient as any);
+
+			const provider = new MCPResourceProvider(mockTransport, undefined, mockLogger);
+
+			await expect(provider.getResources()).rejects.toThrow("MCP client is not connected");
+			expect(mockLogger.error).toHaveBeenCalledWith(
+				"Failed to connect to MCP server:",
+				expect.any(Error),
+			);
+		});
+
+		it("should return resources when client is connected", async () => {
+			const mockResources = {
+				resources: [
+					{
+						uri: "file://test.txt",
+						name: "test.txt",
+						description: "A test file",
+						mimeType: "text/plain",
+					},
+				],
+			};
+
+			const { Client } = await import("@modelcontextprotocol/sdk/client/index.js");
+			const mockClient = {
+				connect: vi.fn().mockResolvedValue(undefined),
+				request: vi.fn().mockResolvedValue(mockResources),
+			};
+			vi.mocked(Client).mockReturnValue(mockClient as any);
+
+			const provider = new MCPResourceProvider(mockTransport, undefined, mockLogger);
+			const resources = await provider.getResources();
+
+			expect(resources).toHaveLength(1);
+			expect(resources[0]).toMatchObject({
+				uri: "file://test.txt",
+				name: "test.txt",
+				description: "A test file",
+				mimeType: "text/plain",
+			});
+			expect(mockLogger.log).toHaveBeenCalledWith("Connected to MCP server");
+		});
+
+		it("should handle empty resources list", async () => {
+			const { Client } = await import("@modelcontextprotocol/sdk/client/index.js");
+			const mockClient = {
+				connect: vi.fn().mockResolvedValue(undefined),
+				request: vi.fn().mockResolvedValue({ resources: [] }),
+			};
+			vi.mocked(Client).mockReturnValue(mockClient as any);
+
+			const provider = new MCPResourceProvider(mockTransport, undefined, mockLogger);
+			const resources = await provider.getResources();
+
+			expect(resources).toHaveLength(0);
+		});
+
+		it("should handle API errors gracefully", async () => {
+			const { Client } = await import("@modelcontextprotocol/sdk/client/index.js");
+			const mockClient = {
+				connect: vi.fn().mockResolvedValue(undefined),
+				request: vi.fn().mockRejectedValue(new Error("API Error")),
+			};
+			vi.mocked(Client).mockReturnValue(mockClient as any);
+
+			const provider = new MCPResourceProvider(mockTransport, undefined, mockLogger);
+
+			await expect(provider.getResources()).rejects.toThrow("API Error");
+		});
+	});
+
+	describe("getResource", () => {
+		it("should throw error when client is not connected", async () => {
+			const { Client } = await import("@modelcontextprotocol/sdk/client/index.js");
+			const mockClient = {
+				connect: vi.fn().mockRejectedValue(new Error("Connection failed")),
+				request: vi.fn(),
+			};
+			vi.mocked(Client).mockReturnValue(mockClient as any);
+
+			const provider = new MCPResourceProvider(mockTransport, undefined, mockLogger);
+
+			await expect(provider.getResource("test://uri")).rejects.toThrow(
+				"MCP client is not connected",
+			);
+		});
+
+		it("should return resource content when successful", async () => {
+			const mockListResponse = {
+				resources: [
+					{
+						uri: "file://test.txt",
+						name: "test.txt",
+						mimeType: "text/plain",
+					},
+				],
+			};
+
+			const mockResourceContent = {
+				contents: [
+					{
+						uri: "file://test.txt",
+						mimeType: "text/plain",
+						text: "Hello, world!",
+					},
+				],
+			};
+
+			const { Client } = await import("@modelcontextprotocol/sdk/client/index.js");
+			const mockClient = {
+				connect: vi.fn().mockResolvedValue(undefined),
+				request: vi.fn()
+					.mockResolvedValueOnce(mockListResponse) // First call for list
+					.mockResolvedValueOnce(mockResourceContent), // Second call for read
+			};
+			vi.mocked(Client).mockReturnValue(mockClient as any);
+
+			const provider = new MCPResourceProvider(mockTransport, undefined, mockLogger);
+			const resource = await provider.getResource("file://test.txt");
+
+			expect(resource).toMatchObject({
+				uri: "file://test.txt",
+				mimeType: "text/plain",
+				data: "Hello, world!",
+			});
+		});
+
+		it("should handle binary resource content", async () => {
+			const mockListResponse = {
+				resources: [
+					{
+						uri: "file://test.bin",
+						name: "test.bin",
+						mimeType: "application/octet-stream",
+					},
+				],
+			};
+
+			const mockResourceContent = {
+				contents: [
+					{
+						uri: "file://test.bin",
+						mimeType: "application/octet-stream",
+						blob: "base64encodeddata",
+					},
+				],
+			};
+
+			const { Client } = await import("@modelcontextprotocol/sdk/client/index.js");
+			const mockClient = {
+				connect: vi.fn().mockResolvedValue(undefined),
+				request: vi.fn()
+					.mockResolvedValueOnce(mockListResponse) // First call for list
+					.mockResolvedValueOnce(mockResourceContent), // Second call for read
+			};
+			vi.mocked(Client).mockReturnValue(mockClient as any);
+
+			const provider = new MCPResourceProvider(mockTransport, undefined, mockLogger);
+			const resource = await provider.getResource("file://test.bin");
+
+			expect(resource).toMatchObject({
+				uri: "file://test.bin",
+				mimeType: "application/octet-stream",
+				data: "base64encodeddata",
+			});
+		});
+
+		it("should handle missing resource", async () => {
+			const mockListResponse = {
+				resources: [], // No resources found
+			};
+
+			const { Client } = await import("@modelcontextprotocol/sdk/client/index.js");
+			const mockClient = {
+				connect: vi.fn().mockResolvedValue(undefined),
+				request: vi.fn().mockResolvedValueOnce(mockListResponse), // Only list call
+			};
+			vi.mocked(Client).mockReturnValue(mockClient as any);
+
+			const provider = new MCPResourceProvider(mockTransport, undefined, mockLogger);
+			const resource = await provider.getResource("file://missing.txt");
+
+			expect(resource).toBeNull();
+		});
+
+		it("should handle API errors gracefully", async () => {
+			const { Client } = await import("@modelcontextprotocol/sdk/client/index.js");
+			const mockClient = {
+				connect: vi.fn().mockResolvedValue(undefined),
+				request: vi.fn().mockRejectedValue(new Error("Resource not found")),
+			};
+			vi.mocked(Client).mockReturnValue(mockClient as any);
+
+			const provider = new MCPResourceProvider(mockTransport, undefined, mockLogger);
+
+			await expect(provider.getResource("file://missing.txt")).rejects.toThrow(
+				"Resource not found",
+			);
+		});
+	});
+
+	describe("connection handling", () => {
+		it("should cache connection promise", async () => {
+			const { Client } = await import("@modelcontextprotocol/sdk/client/index.js");
+			const connectSpy = vi.fn().mockResolvedValue(undefined);
+			const mockClient = {
+				connect: connectSpy,
+				request: vi.fn().mockResolvedValue({ resources: [] }),
+			};
+			vi.mocked(Client).mockReturnValue(mockClient as any);
+
+			const provider = new MCPResourceProvider(mockTransport, undefined, mockLogger);
+
+			// Call getResources multiple times
+			await Promise.all([
+				provider.getResources(),
+				provider.getResources(),
+				provider.getResources(),
+			]);
+
+			// Connection should only be attempted once
+			expect(connectSpy).toHaveBeenCalledTimes(1);
+		});
+
+		it("should handle connection failures consistently", async () => {
+			const { Client } = await import("@modelcontextprotocol/sdk/client/index.js");
+			const mockClient = {
+				connect: vi.fn().mockRejectedValue(new Error("Connection failed")),
+				request: vi.fn(),
+			};
+			vi.mocked(Client).mockReturnValue(mockClient as any);
+
+			const provider = new MCPResourceProvider(mockTransport, undefined, mockLogger);
+
+			// All calls should fail consistently
+			await expect(provider.getResources()).rejects.toThrow("MCP client is not connected");
+			await expect(provider.getResource("test://uri")).rejects.toThrow(
+				"MCP client is not connected",
+			);
+		});
+	});
+
+	describe("error handling", () => {
+		it("should handle malformed response data", async () => {
+			const { Client } = await import("@modelcontextprotocol/sdk/client/index.js");
+			const mockClient = {
+				connect: vi.fn().mockResolvedValue(undefined),
+				request: vi.fn().mockResolvedValue({ invalid: "response" }),
+			};
+			vi.mocked(Client).mockReturnValue(mockClient as any);
+
+			const provider = new MCPResourceProvider(mockTransport, undefined, mockLogger);
+
+			// This should handle malformed responses gracefully
+			await expect(provider.getResources()).resolves.toBeDefined();
+		});
+	});
+});

--- a/src/__tests__/resource.test.ts
+++ b/src/__tests__/resource.test.ts
@@ -1,0 +1,269 @@
+import { describe, expect, it } from "vitest";
+import { type Resource, fromMCPResource, toMCPResource } from "../resources/resource.js";
+
+describe("resource utilities", () => {
+	describe("fromMCPResource", () => {
+		it("should convert MCP resource to generic resource with string data", () => {
+			const mcpResource = {
+				uri: "file://test.txt",
+				name: "test.txt",
+				description: "A test file",
+				mimeType: "text/plain",
+			};
+
+			const data = "Hello, world!";
+			const resource = fromMCPResource(mcpResource, data);
+
+			expect(resource).toEqual({
+				type: "file",
+				uri: "file://test.txt",
+				name: "test.txt",
+				description: "A test file",
+				mimeType: "text/plain",
+				data: "Hello, world!",
+			});
+		});
+
+		it("should convert MCP resource to generic resource with object data", () => {
+			const mcpResource = {
+				uri: "api://users/123",
+				name: "User Profile",
+				description: "User profile data",
+				mimeType: "application/json",
+			};
+
+			const data = { id: 123, name: "John Doe", email: "john@example.com" };
+			const resource = fromMCPResource(mcpResource, data);
+
+			expect(resource).toEqual({
+				type: "api",
+				uri: "api://users/123",
+				name: "User Profile",
+				description: "User profile data",
+				mimeType: "application/json",
+				data: { id: 123, name: "John Doe", email: "john@example.com" },
+			});
+		});
+
+		it("should handle MCP resource without optional fields", () => {
+			const mcpResource = {
+				uri: "simple://resource",
+				name: "Simple Resource",
+			};
+
+			const data = null;
+			const resource = fromMCPResource(mcpResource, data);
+
+			expect(resource).toEqual({
+				type: "simple",
+				uri: "simple://resource",
+				name: "Simple Resource",
+				description: undefined,
+				mimeType: undefined,
+				data: null,
+			});
+		});
+
+		it("should handle URI without protocol", () => {
+			const mcpResource = {
+				uri: "no-protocol-resource",
+				name: "No Protocol",
+			};
+
+			const resource = fromMCPResource(mcpResource, "data");
+
+			expect(resource.type).toBe("unknown");
+		});
+
+		it("should handle complex URI protocols", () => {
+			const mcpResource = {
+				uri: "custom-protocol+subprotocol://path/to/resource",
+				name: "Complex URI",
+			};
+
+			const resource = fromMCPResource(mcpResource, "data");
+
+			expect(resource.type).toBe("custom-protocol+subprotocol");
+		});
+
+		it("should handle undefined data", () => {
+			const mcpResource = {
+				uri: "test://resource",
+				name: "Test",
+			};
+
+			const resource = fromMCPResource(mcpResource, undefined);
+
+			expect(resource.data).toBeUndefined();
+		});
+
+		it("should handle binary data", () => {
+			const mcpResource = {
+				uri: "file://image.png",
+				name: "Image",
+				mimeType: "image/png",
+			};
+
+			const binaryData = new Uint8Array([137, 80, 78, 71]); // PNG header
+			const resource = fromMCPResource(mcpResource, binaryData);
+
+			expect(resource.data).toEqual(binaryData);
+			expect(resource.mimeType).toBe("image/png");
+		});
+	});
+
+	describe("toMCPResource", () => {
+		it("should convert generic resource to MCP format", () => {
+			const resource: Resource<string> = {
+				type: "file",
+				uri: "file://test.txt",
+				name: "test.txt",
+				description: "A test file",
+				mimeType: "text/plain",
+				data: "Hello, world!",
+			};
+
+			const mcpResource = toMCPResource(resource);
+
+			expect(mcpResource).toEqual({
+				uri: "file://test.txt",
+				name: "test.txt",
+				description: "A test file",
+				mimeType: "text/plain",
+			});
+		});
+
+		it("should convert resource without optional fields", () => {
+			const resource: Resource<number> = {
+				type: "number",
+				uri: "test://123",
+				name: "Number Resource",
+				data: 42,
+			};
+
+			const mcpResource = toMCPResource(resource);
+
+			expect(mcpResource).toEqual({
+				uri: "test://123",
+				name: "Number Resource",
+				description: undefined,
+				mimeType: undefined,
+			});
+		});
+
+		it("should exclude data field from MCP format", () => {
+			const resource: Resource<object> = {
+				type: "object",
+				uri: "test://object",
+				name: "Object Resource",
+				description: "An object",
+				mimeType: "application/json",
+				data: { complex: "data", should: "not", be: "included" },
+			};
+
+			const mcpResource = toMCPResource(resource);
+
+			expect(mcpResource).not.toHaveProperty("data");
+			expect(mcpResource).not.toHaveProperty("type");
+			expect(Object.keys(mcpResource)).toEqual(["uri", "name", "description", "mimeType"]);
+		});
+
+		it("should preserve undefined optional fields", () => {
+			const resource: Resource<string> = {
+				type: "test",
+				uri: "test://resource",
+				name: "Test Resource",
+				description: undefined,
+				mimeType: undefined,
+				data: "test data",
+			};
+
+			const mcpResource = toMCPResource(resource);
+
+			expect(mcpResource.description).toBeUndefined();
+			expect(mcpResource.mimeType).toBeUndefined();
+			expect(mcpResource).toHaveProperty("description");
+			expect(mcpResource).toHaveProperty("mimeType");
+		});
+	});
+
+	describe("roundtrip conversion", () => {
+		it("should maintain data integrity in roundtrip conversion (excluding type and data)", () => {
+			const originalMCPResource = {
+				uri: "file://test.txt",
+				name: "test.txt",
+				description: "A test file",
+				mimeType: "text/plain",
+			};
+
+			const data = "Hello, world!";
+
+			// Convert to generic resource and back
+			const genericResource = fromMCPResource(originalMCPResource, data);
+			const backToMCP = toMCPResource(genericResource);
+
+			expect(backToMCP).toEqual(originalMCPResource);
+		});
+
+		it("should handle roundtrip with missing optional fields", () => {
+			const originalMCPResource = {
+				uri: "test://resource",
+				name: "Resource",
+			};
+
+			const genericResource = fromMCPResource(originalMCPResource, null);
+			const backToMCP = toMCPResource(genericResource);
+
+			expect(backToMCP.uri).toBe(originalMCPResource.uri);
+			expect(backToMCP.name).toBe(originalMCPResource.name);
+			expect(backToMCP.description).toBeUndefined();
+			expect(backToMCP.mimeType).toBeUndefined();
+		});
+	});
+
+	describe("type extraction", () => {
+		it("should extract correct types from various URI schemes", () => {
+			const testCases = [
+				{ uri: "http://example.com", expectedType: "http" },
+				{ uri: "https://secure.com", expectedType: "https" },
+				{ uri: "file:///path/to/file", expectedType: "file" },
+				{ uri: "ftp://ftp.example.com", expectedType: "ftp" },
+				{ uri: "custom://resource", expectedType: "custom" },
+				{ uri: "scheme+subscheme://resource", expectedType: "scheme+subscheme" },
+				{ uri: "no-colon-resource", expectedType: "unknown" },
+				{ uri: "://empty-scheme", expectedType: "" },
+				{ uri: "", expectedType: "unknown" },
+			];
+
+			testCases.forEach(({ uri, expectedType }) => {
+				const mcpResource = { uri, name: "test" };
+				const resource = fromMCPResource(mcpResource, null);
+				expect(resource.type).toBe(expectedType);
+			});
+		});
+	});
+
+	describe("data handling", () => {
+		it("should preserve different data types", () => {
+			const testCases = [
+				{ data: "string", type: "string" },
+				{ data: 42, type: "number" },
+				{ data: true, type: "boolean" },
+				{ data: { key: "value" }, type: "object" },
+				{ data: [1, 2, 3], type: "array" },
+				{ data: null, type: "null" },
+				{ data: undefined, type: "undefined" },
+			];
+
+			testCases.forEach(({ data, type }) => {
+				const mcpResource = {
+					uri: `test://${type}`,
+					name: `${type} resource`,
+				};
+
+				const resource = fromMCPResource(mcpResource, data);
+				expect(resource.data).toEqual(data);
+			});
+		});
+	});
+});

--- a/src/__tests__/state.test.ts
+++ b/src/__tests__/state.test.ts
@@ -1,0 +1,368 @@
+import { describe, expect, it } from "vitest";
+import { EditorState } from "@codemirror/state";
+import {
+	resourcesField,
+	updateResources,
+	mcpOptionsField,
+	promptsField,
+	updatePrompts,
+} from "../state.js";
+import { Resource } from "../resources/resource.js";
+import { Prompt } from "@modelcontextprotocol/sdk/types.js";
+
+const createMockResource = (uri: string): Resource => ({
+	uri,
+	name: uri,
+	description: `Test resource: ${uri}`,
+	mimeType: "text/plain",
+	data: undefined,
+});
+
+const createMockPrompt = (name: string): Prompt => ({
+	name,
+	description: `Test prompt: ${name}`,
+	arguments: [],
+});
+
+describe("state", () => {
+	describe("resourcesField", () => {
+		it("should initialize with empty map", () => {
+			const state = EditorState.create({
+				extensions: [resourcesField],
+			});
+
+			const resources = state.field(resourcesField);
+			expect(resources.size).toBe(0);
+		});
+
+		it("should update resources with updateResources effect", () => {
+			const state = EditorState.create({
+				extensions: [resourcesField],
+			});
+
+			const testResources = new Map([
+				["file1.txt", createMockResource("file1.txt")],
+				["file2.txt", createMockResource("file2.txt")],
+			]);
+
+			const newState = state.update({
+				effects: [updateResources.of(testResources)],
+			}).state;
+
+			const resources = newState.field(resourcesField);
+			expect(resources.size).toBe(2);
+			expect(resources.has("file1.txt")).toBe(true);
+			expect(resources.has("file2.txt")).toBe(true);
+			expect(resources.get("file1.txt")?.name).toBe("file1.txt");
+		});
+
+		it("should merge resources when applying multiple updates", () => {
+			const state = EditorState.create({
+				extensions: [resourcesField],
+			});
+
+			const firstBatch = new Map([
+				["file1.txt", createMockResource("file1.txt")],
+			]);
+
+			const secondBatch = new Map([
+				["file2.txt", createMockResource("file2.txt")],
+			]);
+
+			const state1 = state.update({
+				effects: [updateResources.of(firstBatch)],
+			}).state;
+
+			const state2 = state1.update({
+				effects: [updateResources.of(secondBatch)],
+			}).state;
+
+			const resources = state2.field(resourcesField);
+			expect(resources.size).toBe(2);
+			expect(resources.has("file1.txt")).toBe(true);
+			expect(resources.has("file2.txt")).toBe(true);
+		});
+
+		it("should overwrite existing resources with same URI", () => {
+			const state = EditorState.create({
+				extensions: [resourcesField],
+			});
+
+			const original = new Map([
+				["file.txt", createMockResource("file.txt")],
+			]);
+
+			const updated = new Map([
+				["file.txt", { ...createMockResource("file.txt"), description: "Updated description" }],
+			]);
+
+			const state1 = state.update({
+				effects: [updateResources.of(original)],
+			}).state;
+
+			const state2 = state1.update({
+				effects: [updateResources.of(updated)],
+			}).state;
+
+			const resources = state2.field(resourcesField);
+			expect(resources.size).toBe(1);
+			expect(resources.get("file.txt")?.description).toBe("Updated description");
+		});
+
+		it("should handle multiple effects in single transaction", () => {
+			const state = EditorState.create({
+				extensions: [resourcesField],
+			});
+
+			const batch1 = new Map([["file1.txt", createMockResource("file1.txt")]]);
+			const batch2 = new Map([["file2.txt", createMockResource("file2.txt")]]);
+
+			const newState = state.update({
+				effects: [
+					updateResources.of(batch1),
+					updateResources.of(batch2),
+				],
+			}).state;
+
+			const resources = newState.field(resourcesField);
+			expect(resources.size).toBe(2);
+			expect(resources.has("file1.txt")).toBe(true);
+			expect(resources.has("file2.txt")).toBe(true);
+		});
+
+		it("should preserve state when no updateResources effects", () => {
+			const state = EditorState.create({
+				extensions: [resourcesField],
+			});
+
+			const testResources = new Map([
+				["file.txt", createMockResource("file.txt")],
+			]);
+
+			const state1 = state.update({
+				effects: [updateResources.of(testResources)],
+			}).state;
+
+			const state2 = state1.update({
+				changes: { from: 0, to: 0, insert: "test" },
+			}).state;
+
+			const resources = state2.field(resourcesField);
+			expect(resources.size).toBe(1);
+			expect(resources.has("file.txt")).toBe(true);
+		});
+	});
+
+	describe("mcpOptionsField", () => {
+		it("should initialize with undefined handlers", () => {
+			const state = EditorState.create({
+				extensions: [mcpOptionsField],
+			});
+
+			const options = state.field(mcpOptionsField);
+			expect(options.onResourceClick).toBeUndefined();
+			expect(options.onResourceMouseOver).toBeUndefined();
+			expect(options.onResourceMouseOut).toBeUndefined();
+			expect(options.onPromptSubmit).toBeUndefined();
+		});
+
+		it("should maintain the same value across updates", () => {
+			const mockHandlers = {
+				onResourceClick: () => {},
+				onResourceMouseOver: () => {},
+				onResourceMouseOut: () => {},
+				onPromptSubmit: () => {},
+			};
+
+			const state = EditorState.create({
+				extensions: [mcpOptionsField],
+			});
+
+			// The field doesn't have effects to update it, so we test that it preserves values
+			const options = state.field(mcpOptionsField);
+			expect(typeof options).toBe("object");
+		});
+	});
+
+	describe("promptsField", () => {
+		it("should initialize with empty map", () => {
+			const state = EditorState.create({
+				extensions: [promptsField],
+			});
+
+			const prompts = state.field(promptsField);
+			expect(prompts.size).toBe(0);
+		});
+
+		it("should update prompts with updatePrompts effect", () => {
+			const state = EditorState.create({
+				extensions: [promptsField],
+			});
+
+			const testPrompts = new Map([
+				["prompt1", createMockPrompt("prompt1")],
+				["prompt2", createMockPrompt("prompt2")],
+			]);
+
+			const newState = state.update({
+				effects: [updatePrompts.of(testPrompts)],
+			}).state;
+
+			const prompts = newState.field(promptsField);
+			expect(prompts.size).toBe(2);
+			expect(prompts.has("prompt1")).toBe(true);
+			expect(prompts.has("prompt2")).toBe(true);
+			expect(prompts.get("prompt1")?.name).toBe("prompt1");
+		});
+
+		it("should merge prompts when applying multiple updates", () => {
+			const state = EditorState.create({
+				extensions: [promptsField],
+			});
+
+			const firstBatch = new Map([
+				["prompt1", createMockPrompt("prompt1")],
+			]);
+
+			const secondBatch = new Map([
+				["prompt2", createMockPrompt("prompt2")],
+			]);
+
+			const state1 = state.update({
+				effects: [updatePrompts.of(firstBatch)],
+			}).state;
+
+			const state2 = state1.update({
+				effects: [updatePrompts.of(secondBatch)],
+			}).state;
+
+			const prompts = state2.field(promptsField);
+			expect(prompts.size).toBe(2);
+			expect(prompts.has("prompt1")).toBe(true);
+			expect(prompts.has("prompt2")).toBe(true);
+		});
+
+		it("should overwrite existing prompts with same name", () => {
+			const state = EditorState.create({
+				extensions: [promptsField],
+			});
+
+			const original = new Map([
+				["prompt", createMockPrompt("prompt")],
+			]);
+
+			const updated = new Map([
+				["prompt", { ...createMockPrompt("prompt"), description: "Updated description" }],
+			]);
+
+			const state1 = state.update({
+				effects: [updatePrompts.of(original)],
+			}).state;
+
+			const state2 = state1.update({
+				effects: [updatePrompts.of(updated)],
+			}).state;
+
+			const prompts = state2.field(promptsField);
+			expect(prompts.size).toBe(1);
+			expect(prompts.get("prompt")?.description).toBe("Updated description");
+		});
+
+		it("should handle multiple effects in single transaction", () => {
+			const state = EditorState.create({
+				extensions: [promptsField],
+			});
+
+			const batch1 = new Map([["prompt1", createMockPrompt("prompt1")]]);
+			const batch2 = new Map([["prompt2", createMockPrompt("prompt2")]]);
+
+			const newState = state.update({
+				effects: [
+					updatePrompts.of(batch1),
+					updatePrompts.of(batch2),
+				],
+			}).state;
+
+			const prompts = newState.field(promptsField);
+			expect(prompts.size).toBe(2);
+			expect(prompts.has("prompt1")).toBe(true);
+			expect(prompts.has("prompt2")).toBe(true);
+		});
+
+		it("should preserve state when no updatePrompts effects", () => {
+			const state = EditorState.create({
+				extensions: [promptsField],
+			});
+
+			const testPrompts = new Map([
+				["prompt", createMockPrompt("prompt")],
+			]);
+
+			const state1 = state.update({
+				effects: [updatePrompts.of(testPrompts)],
+			}).state;
+
+			const state2 = state1.update({
+				changes: { from: 0, to: 0, insert: "test" },
+			}).state;
+
+			const prompts = state2.field(promptsField);
+			expect(prompts.size).toBe(1);
+			expect(prompts.has("prompt")).toBe(true);
+		});
+	});
+
+	describe("integration tests", () => {
+		it("should handle both resources and prompts in same state", () => {
+			const state = EditorState.create({
+				extensions: [resourcesField, promptsField, mcpOptionsField],
+			});
+
+			const testResources = new Map([
+				["file.txt", createMockResource("file.txt")],
+			]);
+
+			const testPrompts = new Map([
+				["prompt", createMockPrompt("prompt")],
+			]);
+
+			const newState = state.update({
+				effects: [
+					updateResources.of(testResources),
+					updatePrompts.of(testPrompts),
+				],
+			}).state;
+
+			expect(newState.field(resourcesField).size).toBe(1);
+			expect(newState.field(promptsField).size).toBe(1);
+		});
+
+		it("should maintain separate state for resources and prompts", () => {
+			const state = EditorState.create({
+				extensions: [resourcesField, promptsField],
+			});
+
+			const testResources = new Map([
+				["item", createMockResource("item")],
+			]);
+
+			const testPrompts = new Map([
+				["item", createMockPrompt("item")],
+			]);
+
+			const newState = state.update({
+				effects: [
+					updateResources.of(testResources),
+					updatePrompts.of(testPrompts),
+				],
+			}).state;
+
+			const resources = newState.field(resourcesField);
+			const prompts = newState.field(promptsField);
+
+			expect(resources.get("item")?.uri).toBe("item");
+			expect(prompts.get("item")?.name).toBe("item");
+			expect(resources.get("item")).not.toBe(prompts.get("item"));
+		});
+	});
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,19 @@
-export { mcpExtension, extractResources } from "./mcp.js";
+export { mcpExtension } from "./mcp.js";
+
+export { extractResources } from "./resources/extract.js";
+
+export type {
+	Resource,
+	ResourceProvider,
+	ResourceCompletionOptions,
+} from "./resources/resource.js";
+
+export { resourcesField } from "./state.js";
+export { resourceCompletion } from "./resources/completion.js";
+
+export {
+	hoverResource,
+	createDefaultTooltip,
+} from "./resources/hover.js";
+
+export { resourceTheme } from "./theme.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,4 +16,5 @@ export {
 	createDefaultTooltip,
 } from "./resources/hover.js";
 
+export { resourceInputFilter } from "./resources/input-filter.js";
 export { resourceTheme } from "./theme.js";

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -13,6 +13,7 @@ import { MCPResourceProvider } from "./mcp/mcp-provider.js";
 import { resourceCompletion } from "./resources/completion.js";
 import { resourceDecorations } from "./resources/decoration.js";
 import { type HoverResourceOptions, hoverResource } from "./resources/hover.js";
+import { resourceInputFilter } from "./resources/input-filter.js";
 import { type Resource, toMCPResource } from "./resources/resource.js";
 import { mcpOptionsField, promptsField, resourcesField, updatePrompts } from "./state.js";
 import { resourceTheme } from "./theme.js";
@@ -182,6 +183,7 @@ export function mcpExtension(options: MCPOptions): Extension {
 		resourceTheme,
 		hoverResource(options.hoverOptions ?? {}),
 		resourceDecorations,
+		resourceInputFilter,
 		mcpOptionsField.init(() => ({
 			onResourceClick: adaptResource(options.onResourceClick),
 			onResourceMouseOver: adaptResource(options.onResourceMouseOver),

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -1,27 +1,21 @@
 import { type Completion, type CompletionContext, autocompletion } from "@codemirror/autocomplete";
 import type { Extension } from "@codemirror/state";
-import type { EditorView } from "@codemirror/view";
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import {
 	GetPromptResultSchema,
 	type Implementation,
 	ListPromptsResultSchema,
-	ListResourcesResultSchema,
+	type Resource as MCPResource,
 	type PromptMessage,
-	type Resource,
 } from "@modelcontextprotocol/sdk/types.js";
-import { resourceDecorations } from "./decoration.js";
-import { hoverResource } from "./hover.js";
-import {
-	mcpOptionsField,
-	promptsField,
-	resourcesField,
-	updatePrompts,
-	updateResources,
-} from "./state.js";
+import { MCPResourceProvider } from "./mcp/mcp-provider.js";
+import { resourceCompletion } from "./resources/completion.js";
+import { resourceDecorations } from "./resources/decoration.js";
+import { type HoverResourceOptions, hoverResource } from "./resources/hover.js";
+import { type Resource, toMCPResource } from "./resources/resource.js";
+import { mcpOptionsField, promptsField, resourcesField, updatePrompts } from "./state.js";
 import { resourceTheme } from "./theme.js";
-import { matchAllURIs } from "./utils.js";
 
 export interface MCPOptions {
 	/** Transport layer for MCP client-server communication */
@@ -31,81 +25,25 @@ export interface MCPOptions {
 	/** Optional logger for debugging, defaults to console */
 	logger?: typeof console;
 	/** Optional callback when a resource is clicked */
-	onResourceClick?: (resource: Resource) => void;
+	onResourceClick?: (resource: MCPResource) => void;
 	/** Optional callback when hovering over a resource */
-	onResourceMouseOver?: (resource: Resource) => void;
+	onResourceMouseOver?: (resource: MCPResource) => void;
 	/** Optional callback when hovering out of a resource */
-	onResourceMouseOut?: (resource: Resource) => void;
+	onResourceMouseOut?: (resource: MCPResource) => void;
 	/** Optional callback when a prompt is triggered */
 	onPromptSubmit?: (opts: { messages: PromptMessage[] }) => void;
+
+	/** Optional hover options */
+	hoverOptions?: HoverResourceOptions;
 }
 
 interface CompletionHandlerContext {
 	word: { from: number; to: number } | null;
 	connected: boolean;
+	resourceProvider: MCPResourceProvider;
 	client: Client;
 	logger?: typeof console;
 	context: CompletionContext;
-}
-
-async function handleResourceCompletion({
-	word,
-	connected,
-	client,
-	logger,
-	context,
-}: CompletionHandlerContext) {
-	if (!word) return null;
-	if (word.from === word.to && !context.explicit) return null;
-	if (!connected) {
-		logger?.error("MCP client is not connected");
-		return null;
-	}
-
-	logger?.log("Fetching resources from MCP server");
-
-	try {
-		// Fetch resources from MCP server
-		const response = await client.request({ method: "resources/list" }, ListResourcesResultSchema);
-		const resources = response.resources;
-		if (resources.length === 0) {
-			return null;
-		}
-		const effects = updateResources.of(
-			new Map(resources.map((resource) => [resource.uri, resource])),
-		);
-
-		if (context.view) {
-			context.view.dispatch({ effects });
-		}
-
-		logger?.log(`Got ${resources.length} resources from MCP server`);
-
-		// Convert resources to completion items
-		const options = resources.map(
-			(resource: Resource): Completion => ({
-				label: `@${resource.name}`,
-				displayLabel: resource.name,
-				detail: resource.uri,
-				info: resource.description || undefined,
-				type: resource.mimeType ? "constant" : "variable",
-				boost: resource.description ? 100 : 0,
-				apply: (view, _completion, from, to) => {
-					view.dispatch({
-						changes: { from, to, insert: `@${resource.uri}` },
-					});
-				},
-			}),
-		);
-
-		return {
-			from: word.from,
-			options,
-		};
-	} catch (error) {
-		logger?.error("Failed to fetch MCP resources:", error);
-		return null;
-	}
 }
 
 async function handlePromptCompletion({
@@ -186,76 +124,42 @@ async function handlePromptCompletion({
 	}
 }
 
-export function extractResources(view: EditorView): Array<{
-	resource: Resource;
-	start: number;
-	end: number;
-}> {
-	const text = view.state.doc.toString();
-	const resources = view.state.field(resourcesField);
-	const matches: Array<{
-		resource: Resource;
-		// Position in the text, including the @ prefix
-		start: number;
-		end: number;
-	}> = [];
-	for (const match of matchAllURIs(text)) {
-		const start = match.index;
-		const end = start + match[0].length;
-
-		const uri = match[0].slice(1); // Remove @ prefix
-		const resource = resources.get(uri);
-		if (resource) {
-			matches.push({ resource, start, end });
-		}
-	}
-	return matches;
-}
-
 export function mcpExtension(options: MCPOptions): Extension {
 	const logger = options.logger;
-	const client = new Client(
-		{
-			name: options.clientOptions?.name ?? "codemirror-mcp",
-			version: options.clientOptions?.version ?? "0.1.0",
-		},
-		{
-			capabilities: {},
-		},
+	const resourceProvider = new MCPResourceProvider(
+		options.transport,
+		options.clientOptions,
+		logger,
 	);
-
-	const connectedPromise = client
-		.connect(options.transport)
-		.then(() => {
-			logger?.log("Connected to MCP server");
-			return true;
-		})
-		.catch((error) => {
-			logger?.error("Failed to connect to MCP server:", error);
-			return false;
-		});
 
 	const completion = autocompletion({
 		override: [
 			async (context: CompletionContext) => {
-				const connected = await connectedPromise;
-				const handlerContext: Omit<CompletionHandlerContext, "word"> = {
-					connected,
-					client,
-					logger,
-					context,
-				};
-
 				// Handle resource completions (@)
 				const resourceWord = context.matchBefore(/@(\w+)?/);
 				if (resourceWord) {
-					return handleResourceCompletion({ ...handlerContext, word: resourceWord });
+					const connected = await resourceProvider.isConnected();
+					if (!connected) {
+						logger?.error("MCP client is not connected");
+						return null;
+					}
+
+					logger?.log("Fetching resources from MCP server");
+
+					return resourceCompletion(() => resourceProvider.getResources())(context);
 				}
 
 				// Handle prompt completions (/)
 				const promptWord = context.matchBefore(/\/(\w+)?/);
 				if (promptWord) {
-					return handlePromptCompletion({ ...handlerContext, word: promptWord });
+					return handlePromptCompletion({
+						connected: await resourceProvider.isConnected(),
+						resourceProvider,
+						client: resourceProvider.getClient(),
+						logger,
+						context,
+						word: promptWord,
+					});
 				}
 
 				return null;
@@ -263,17 +167,25 @@ export function mcpExtension(options: MCPOptions): Extension {
 		],
 	});
 
+	const adaptResource = (callback?: (resource: MCPResource) => void) => {
+		if (!callback) return undefined;
+
+		return (mcpResource: Resource) => {
+			callback(toMCPResource(mcpResource));
+		};
+	};
+
 	return [
 		resourcesField,
 		promptsField,
 		completion,
 		resourceTheme,
-		hoverResource(),
+		hoverResource(options.hoverOptions ?? {}),
 		resourceDecorations,
 		mcpOptionsField.init(() => ({
-			onResourceClick: options.onResourceClick,
-			onResourceMouseOver: options.onResourceMouseOver,
-			onResourceMouseOut: options.onResourceMouseOut,
+			onResourceClick: adaptResource(options.onResourceClick),
+			onResourceMouseOver: adaptResource(options.onResourceMouseOver),
+			onResourceMouseOut: adaptResource(options.onResourceMouseOut),
 			onPromptSubmit: options.onPromptSubmit,
 		})),
 	];

--- a/src/mcp/mcp-provider.ts
+++ b/src/mcp/mcp-provider.ts
@@ -1,0 +1,124 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import {
+	type Implementation,
+	ListResourcesResultSchema,
+	ReadResourceResultSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import { type Resource, type ResourceProvider, fromMCPResource } from "../resources/resource.js";
+
+/**
+ * MCP-specific resource provider that implements the generic ResourceProvider interface
+ */
+export class MCPResourceProvider implements ResourceProvider<string> {
+	private client: Client;
+	private connectedPromise: Promise<boolean>;
+
+	constructor(
+		transport: Transport,
+		clientOptions?: Implementation,
+		private logger?: typeof console,
+	) {
+		this.client = new Client(
+			{
+				name: clientOptions?.name ?? "codemirror-mcp",
+				version: clientOptions?.version ?? "0.1.0",
+			},
+			{
+				capabilities: {},
+			},
+		);
+
+		this.connectedPromise = this.client
+			.connect(transport)
+			.then(() => {
+				this.logger?.log("Connected to MCP server");
+				return true;
+			})
+			.catch((error) => {
+				this.logger?.error("Failed to connect to MCP server:", error);
+				return false;
+			});
+	}
+
+	async getResources(): Promise<Resource<string>[]> {
+		const connected = await this.connectedPromise;
+		if (!connected) {
+			throw new Error("MCP client is not connected");
+		}
+
+		try {
+			const response = await this.client.request(
+				{ method: "resources/list" },
+				ListResourcesResultSchema,
+			);
+
+			const resources: Resource<string>[] = [];
+
+			// For each resource, we could potentially read its content
+			// For now, we'll just return the resource metadata with empty data
+			for (const mcpResource of response.resources) {
+				resources.push(fromMCPResource(mcpResource, ""));
+			}
+
+			return resources;
+		} catch (error) {
+			this.logger?.error("Failed to fetch MCP resources:", error);
+			throw error;
+		}
+	}
+
+	async getResource(uri: string): Promise<Resource<string> | null> {
+		const connected = await this.connectedPromise;
+		if (!connected) {
+			throw new Error("MCP client is not connected");
+		}
+
+		try {
+			// First get the resource metadata
+			const listResponse = await this.client.request(
+				{ method: "resources/list" },
+				ListResourcesResultSchema,
+			);
+
+			const mcpResource = listResponse.resources.find((r) => r.uri === uri);
+			if (!mcpResource) {
+				return null;
+			}
+
+			// Try to read the resource content
+			let content = "";
+			try {
+				const readResponse = await this.client.request(
+					{ method: "resources/read", params: { uri } },
+					ReadResourceResultSchema,
+				);
+
+				// Combine all content parts
+				content = readResponse.contents.map((c) => c.text || c.blob || "").join("\n");
+			} catch (error) {
+				this.logger?.warn(`Could not read resource ${uri}:`, error);
+				// Continue with empty content
+			}
+
+			return fromMCPResource(mcpResource, content);
+		} catch (error) {
+			this.logger?.error("Failed to get MCP resource:", error);
+			throw error;
+		}
+	}
+
+	/**
+	 * Get the underlying MCP client for advanced usage
+	 */
+	getClient(): Client {
+		return this.client;
+	}
+
+	/**
+	 * Check if the client is connected
+	 */
+	async isConnected(): Promise<boolean> {
+		return this.connectedPromise;
+	}
+}

--- a/src/mcp/mcp-provider.ts
+++ b/src/mcp/mcp-provider.ts
@@ -55,6 +55,12 @@ export class MCPResourceProvider implements ResourceProvider<string> {
 
 			const resources: Resource<string>[] = [];
 
+			// Guard against malformed response data
+			if (!response.resources || !Array.isArray(response.resources)) {
+				this.logger?.warn("Malformed response: resources is not an array");
+				return [];
+			}
+
 			// For each resource, we could potentially read its content
 			// For now, we'll just return the resource metadata with empty data
 			for (const mcpResource of response.resources) {
@@ -80,6 +86,12 @@ export class MCPResourceProvider implements ResourceProvider<string> {
 				{ method: "resources/list" },
 				ListResourcesResultSchema,
 			);
+
+			// Guard against malformed response data
+			if (!listResponse.resources || !Array.isArray(listResponse.resources)) {
+				this.logger?.warn("Malformed response: resources is not an array");
+				return null;
+			}
 
 			const mcpResource = listResponse.resources.find((r) => r.uri === uri);
 			if (!mcpResource) {

--- a/src/resources/completion.ts
+++ b/src/resources/completion.ts
@@ -37,7 +37,7 @@ export const resourceCompletion = (
 				...formatResource?.(resource),
 				apply: (view, _completion, from, to) => {
 					view.dispatch({
-						changes: { from, to, insert: `@${resource.uri}` },
+						changes: { from, to, insert: `@${resource.uri} ` },
 					});
 				},
 			}),

--- a/src/resources/completion.ts
+++ b/src/resources/completion.ts
@@ -1,0 +1,51 @@
+import type { Completion, CompletionSource } from "@codemirror/autocomplete";
+import { updateResources } from "../state.js";
+import type { Resource } from "./resource.js";
+
+export const resourceCompletion = (
+	getResources: () => Promise<Resource[]>,
+	formatResource?: (resource: Resource) => Partial<Completion>,
+): CompletionSource => {
+	return async (context) => {
+		// Handle resource completions (@)
+		const resourceWord = context.matchBefore(/@(\w+)?/);
+		if (!resourceWord) return null;
+		if (resourceWord.from === resourceWord.to && !context.explicit) return null;
+
+		const resources = await getResources();
+		if (resources.length === 0) {
+			return null;
+		}
+		const effects = updateResources.of(
+			new Map(resources.map((resource) => [resource.uri, resource])),
+		);
+
+		if (context.view) {
+			context.view.dispatch({ effects });
+		}
+
+		// Convert resources to completion items
+		const options = resources.map(
+			(resource: Resource): Completion => ({
+				label: `@${resource.name}`,
+				displayLabel: resource.name,
+				detail: resource.uri,
+				info: resource.description || undefined,
+				type: resource.mimeType ? "constant" : "variable",
+				boost: resource.description ? 100 : 0,
+				// Override with custom formatter
+				...formatResource?.(resource),
+				apply: (view, _completion, from, to) => {
+					view.dispatch({
+						changes: { from, to, insert: `@${resource.uri}` },
+					});
+				},
+			}),
+		);
+
+		return {
+			from: resourceWord.from,
+			options,
+		};
+	};
+};

--- a/src/resources/decoration.ts
+++ b/src/resources/decoration.ts
@@ -7,9 +7,9 @@ import {
 	type ViewUpdate,
 	WidgetType,
 } from "@codemirror/view";
-import type { Resource } from "@modelcontextprotocol/sdk/types.js";
-import { mcpOptionsField, resourcesField, updateResources } from "./state.js";
-import { matchAllURIs } from "./utils.js";
+import { mcpOptionsField, resourcesField, updateResources } from "../state.js";
+import { matchAllURIs } from "../utils.js";
+import type { Resource } from "./resource.js";
 
 // Widget for resource decoration
 class ResourceWidget extends WidgetType {

--- a/src/resources/extract.ts
+++ b/src/resources/extract.ts
@@ -1,0 +1,30 @@
+import type { EditorView } from "@codemirror/view";
+import { resourcesField } from "../state.js";
+import { matchAllURIs } from "../utils.js";
+import type { Resource } from "./resource.js";
+
+export function extractResources(view: EditorView): Array<{
+	resource: Resource;
+	start: number;
+	end: number;
+}> {
+	const text = view.state.doc.toString();
+	const resources = view.state.field(resourcesField);
+	const matches: Array<{
+		resource: Resource;
+		// Position in the text, including the @ prefix
+		start: number;
+		end: number;
+	}> = [];
+	for (const match of matchAllURIs(text)) {
+		const start = match.index;
+		const end = start + match[0].length;
+
+		const uri = match[0].slice(1); // Remove @ prefix
+		const resource = resources.get(uri);
+		if (resource) {
+			matches.push({ resource: resource, start, end });
+		}
+	}
+	return matches;
+}

--- a/src/resources/hover.ts
+++ b/src/resources/hover.ts
@@ -65,7 +65,8 @@ export function hoverResource(options: HoverResourceOptions) {
 		const { from, text } = view.state.doc.lineAt(pos);
 		const resources = view.state.field(resourcesField);
 
-		const result = findResourceAtPosition(text, pos - from, resources, from);
+		// Fallback: try to find resource in the document text (works for non-decorated resources)
+		const result = findResourceAtPosition(text, pos, resources, from);
 		if (!result) return null;
 
 		return {

--- a/src/resources/hover.ts
+++ b/src/resources/hover.ts
@@ -1,9 +1,9 @@
 import { type TooltipView, hoverTooltip } from "@codemirror/view";
-import type { Resource } from "@modelcontextprotocol/sdk/types.js";
-import { resourcesField } from "./state.js";
-import { matchAllURIs } from "./utils.js";
+import { resourcesField } from "../state.js";
+import { matchAllURIs } from "../utils.js";
+import type { Resource } from "./resource.js";
 
-export function createTooltip(resource: Resource): TooltipView {
+export function createDefaultTooltip(resource: Resource): TooltipView {
 	const dom = document.createElement("div");
 	dom.className = "cm-tooltip-cursor";
 
@@ -56,7 +56,11 @@ export function findResourceAtPosition(
 	return null;
 }
 
-export function hoverResource() {
+export interface HoverResourceOptions {
+	createTooltip?: (resource: Resource) => TooltipView;
+}
+
+export function hoverResource(options: HoverResourceOptions) {
 	return hoverTooltip((view, pos) => {
 		const { from, text } = view.state.doc.lineAt(pos);
 		const resources = view.state.field(resourcesField);
@@ -69,6 +73,7 @@ export function hoverResource() {
 			end: result.end,
 			above: true,
 			create() {
+				const createTooltip = options.createTooltip ?? createDefaultTooltip;
 				return createTooltip(result.resource);
 			},
 		};

--- a/src/resources/input-filter.ts
+++ b/src/resources/input-filter.ts
@@ -1,0 +1,95 @@
+import { EditorState, Transaction } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { resourcesField } from "../state.js";
+import { matchAllURIs } from "../utils.js";
+
+/**
+ * Check if cursor is at the end of a resource
+ */
+function getResourceAtCursor(
+	state: EditorState,
+	pos: number,
+): { from: number; to: number; uri: string } | null {
+	const resources = state.field(resourcesField);
+	const doc = state.doc;
+
+	// Look backward from cursor to find resource
+	const lineStart = doc.lineAt(pos).from;
+	const textBefore = doc.sliceString(lineStart, pos);
+
+	// Find all resources in the line up to cursor
+	const matches = Array.from(matchAllURIs(textBefore));
+	if (matches.length === 0) return null;
+
+	// Get the last match (closest to cursor)
+	const lastMatch = matches[matches.length - 1];
+	const resourceStart = lineStart + lastMatch.index;
+	const resourceEnd = resourceStart + lastMatch[0].length;
+	const uri = lastMatch[0].slice(1); // Remove @ prefix
+
+	// Check if cursor is at the end of this resource and resource exists
+	if (pos === resourceEnd && resources.has(uri)) {
+		return { from: resourceStart, to: resourceEnd, uri };
+	}
+
+	return null;
+}
+
+/**
+ * Check if cursor is at the beginning of a resource
+ */
+function getResourceAfterCursor(
+	state: EditorState,
+	pos: number,
+): { from: number; to: number; uri: string } | null {
+	const resources = state.field(resourcesField);
+	const doc = state.doc;
+
+	// Look forward from cursor to find resource
+	const lineEnd = doc.lineAt(pos).to;
+	const textAfter = doc.sliceString(pos, lineEnd);
+
+	// Find resource starting at cursor position
+	const matches = Array.from(matchAllURIs(textAfter));
+	if (matches.length === 0) return null;
+
+	const firstMatch = matches[0];
+	if (firstMatch.index !== 0) return null; // Resource must start at cursor
+
+	const resourceStart = pos;
+	const resourceEnd = pos + firstMatch[0].length;
+	const uri = firstMatch[0].slice(1); // Remove @ prefix
+
+	// Check if resource exists
+	if (resources.has(uri)) {
+		return { from: resourceStart, to: resourceEnd, uri };
+	}
+
+	return null;
+}
+
+export const resourceInputFilter = EditorState.transactionFilter.of((tr: Transaction) => {
+	// Only care about explicit delete.backward/delete.forward
+	const del = tr.annotation(Transaction.userEvent);
+	if (del !== "delete.backward" && del !== "delete.forward") return tr;
+
+	const sel = tr.startState.selection.main;
+	if (!sel.empty) return tr;
+
+	let resource: { from: number; to: number; uri: string } | null = null;
+	if (del === "delete.backward") {
+		resource = getResourceAtCursor(tr.startState, sel.head);
+	} else if (del === "delete.forward") {
+		resource = getResourceAfterCursor(tr.startState, sel.head);
+	}
+	if (!resource) return tr;
+
+	// Replace the resource with nothing, keep cursor at start
+	return [
+		{
+			changes: { from: resource.from, to: resource.to, insert: "" },
+			selection: { anchor: resource.from },
+			scrollIntoView: true,
+		},
+	];
+});

--- a/src/resources/input-filter.ts
+++ b/src/resources/input-filter.ts
@@ -1,5 +1,4 @@
 import { EditorState, Transaction } from "@codemirror/state";
-import { EditorView } from "@codemirror/view";
 import { resourcesField } from "../state.js";
 import { matchAllURIs } from "../utils.js";
 
@@ -23,9 +22,10 @@ function getResourceAtCursor(
 
 	// Get the last match (closest to cursor)
 	const lastMatch = matches[matches.length - 1];
+	if (!lastMatch) return null;
 	const resourceStart = lineStart + lastMatch.index;
 	const resourceEnd = resourceStart + lastMatch[0].length;
-	const uri = lastMatch[0].slice(1); // Remove @ prefix
+	const uri = lastMatch[0].slice(1); // Remove @ prefix\
 
 	// Check if cursor is at the end of this resource and resource exists
 	if (pos === resourceEnd && resources.has(uri)) {
@@ -54,6 +54,7 @@ function getResourceAfterCursor(
 	if (matches.length === 0) return null;
 
 	const firstMatch = matches[0];
+	if (!firstMatch) return null;
 	if (firstMatch.index !== 0) return null; // Resource must start at cursor
 
 	const resourceStart = pos;

--- a/src/resources/resource.ts
+++ b/src/resources/resource.ts
@@ -54,8 +54,19 @@ export function fromMCPResource<T = unknown>(
 	},
 	data: T,
 ): Resource<T> {
+	const protocolMatch = mcpResource.uri.split("://");
+	let type: string;
+
+	if (protocolMatch.length > 1) {
+		// Has protocol separator - use the first part as type
+		type = protocolMatch[0] ?? "unknown";
+	} else {
+		// No protocol separator - mark as unknown
+		type = "unknown";
+	}
+
 	return {
-		type: mcpResource.uri.split("://")[0] ?? "unknown",
+		type,
 		uri: mcpResource.uri,
 		name: mcpResource.name,
 		description: mcpResource.description,

--- a/src/resources/resource.ts
+++ b/src/resources/resource.ts
@@ -1,0 +1,82 @@
+/**
+ * Generic resource abstraction that can work with MCP and other backends
+ */
+
+export interface Resource<T = unknown> {
+	/** Type of the resource */
+	type: string;
+	/** Unique identifier for the resource */
+	uri: string;
+	/** Display name for the resource */
+	name: string;
+	/** Optional description of the resource */
+	description?: string;
+	/** MIME type of the resource */
+	mimeType?: string;
+	/** The actual resource data */
+	data: T;
+}
+
+export interface ResourceProvider<T = unknown> {
+	/** Get all available resources */
+	getResources(): Promise<Resource<T>[]>;
+	/** Get a specific resource by URI */
+	getResource?(uri: string): Promise<Resource<T> | null>;
+}
+
+/**
+ * Generic resource completion options
+ */
+export interface ResourceCompletionOptions<T = unknown> {
+	/** Resource provider to fetch resources from */
+	provider: ResourceProvider<T>;
+	/** Optional prefix for resource mentions (defaults to '@') */
+	prefix?: string;
+	/** Optional logger for debugging */
+	logger?: typeof console;
+	/** Optional callback when a resource is clicked */
+	onResourceClick?: (resource: Resource<T>) => void;
+	/** Optional callback when hovering over a resource */
+	onResourceMouseOver?: (resource: Resource<T>) => void;
+	/** Optional callback when hovering out of a resource */
+	onResourceMouseOut?: (resource: Resource<T>) => void;
+}
+
+/**
+ * Convert MCP Resource to generic Resource<T>
+ */
+export function fromMCPResource<T = unknown>(
+	mcpResource: {
+		uri: string;
+		name: string;
+		description?: string;
+		mimeType?: string;
+	},
+	data: T,
+): Resource<T> {
+	return {
+		type: mcpResource.uri.split("://")[0] ?? "unknown",
+		uri: mcpResource.uri,
+		name: mcpResource.name,
+		description: mcpResource.description,
+		mimeType: mcpResource.mimeType,
+		data,
+	};
+}
+
+/**
+ * Convert generic Resource<T> to MCP Resource format
+ */
+export function toMCPResource<T>(resource: Resource<T>): {
+	uri: string;
+	name: string;
+	description?: string;
+	mimeType?: string;
+} {
+	return {
+		uri: resource.uri,
+		name: resource.name,
+		description: resource.description,
+		mimeType: resource.mimeType,
+	};
+}

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,5 +1,6 @@
 import { StateEffect, type StateEffectType, StateField } from "@codemirror/state";
-import type { Prompt, PromptMessage, Resource } from "@modelcontextprotocol/sdk/types.js";
+import type { Prompt, PromptMessage } from "@modelcontextprotocol/sdk/types.js";
+import type { Resource } from "./resources/resource.js";
 
 type ResourceURI = string;
 type ResourceMap = Map<ResourceURI, Resource>;

--- a/src/state.ts
+++ b/src/state.ts
@@ -14,17 +14,20 @@ export const resourcesField: StateField<ResourceMap> = StateField.define<Resourc
 		return new Map<ResourceURI, Resource>();
 	},
 	update(oldResources, tr) {
+		let updated = false;
+		let newResources = oldResources;
 		for (const e of tr.effects) {
 			if (e.is(updateResources)) {
-				// merge resources
-				const newResources = new Map<ResourceURI, Resource>(oldResources);
+				if (!updated) {
+					newResources = new Map<ResourceURI, Resource>(oldResources);
+					updated = true;
+				}
 				for (const [resourceURI, resource] of e.value) {
 					newResources.set(resourceURI, resource);
 				}
-				return newResources;
 			}
 		}
-		return oldResources;
+		return newResources;
 	},
 });
 
@@ -60,16 +63,19 @@ export const promptsField = StateField.define<PromptMap>({
 		return new Map<string, Prompt>();
 	},
 	update(oldPrompts, tr) {
+		let updated = false;
+		let newPrompts = oldPrompts;
 		for (const e of tr.effects) {
 			if (e.is(updatePrompts)) {
-				// merge prompts
-				const newPrompts = new Map<string, Prompt>(oldPrompts);
+				if (!updated) {
+					newPrompts = new Map<string, Prompt>(oldPrompts);
+					updated = true;
+				}
 				for (const [name, prompt] of e.value) {
 					newPrompts.set(name, prompt);
 				}
-				return newPrompts;
 			}
 		}
-		return oldPrompts;
+		return newPrompts;
 	},
 });


### PR DESCRIPTION
Exports more granular extensions for `@` resources for completions and decorating resources.