### PR TITLE
chore(ci): add --ignore-scripts to release installs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,10 +28,10 @@ jobs:
           cache: pnpm
 
       - name: ⎔ Upgrade npm for OIDC support
-        run: pnpm install -g npm@latest
+        run: pnpm install --ignore-scripts -g npm@latest
 
       - name: 📥 Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --ignore-scripts --frozen-lockfile
 
       - name: 🔍 Type Check
         run: pnpm run typecheck


### PR DESCRIPTION
Defense-in-depth against compromised transitive deps executing postinstall/prepare during release. Motivated by the TanStack npm supply-chain compromise (May 2026).

No functional change.