### PR TITLE
fix(ci): bump release publish-job node to 24 for npm OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: ⎔ Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 22
+          node-version: 24
           registry-url: 'https://registry.npmjs.org'
           cache: pnpm
 


### PR DESCRIPTION
`npm install -g npm@latest` was recently removed, but the release.yml `publish` step still pins `node-version: 22` (or `20`), whose bundled npm 10.x does not support npm trusted publishing (OIDC). This restores OIDC by bumping the publish step to node 24 (bundled npm 11+).

Once this lands, the next `v*` tag will publish successfully via OIDC.