### PR TITLE
fix(ci): correct release.yml publish job indentation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
       - name: ⎔ Setup pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
-            - name: ⎔ Setup Node.js
+      - name: ⎔ Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24


### PR DESCRIPTION
Fixes pre-existing YAML indentation bug in the publish job that was causing release.yml to fail at parse time (0s duration on every run). Flagged by Copilot review on #13.