### PR TITLE
ci: enforce lint on PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,9 @@ jobs:
       - name: 📥 Install dependencies
         run: pnpm install --ignore-scripts --frozen-lockfile
 
+      - name: 🧹 Lint
+        run: pnpm exec biome ci .
+
       - name: 🔍 Type Check
         run: pnpm run typecheck
 


### PR DESCRIPTION
## What changed

Adds a non-mutating lint step (`pnpm exec biome ci .`) to the `test` job in `.github/workflows/test.yml`, running after dependency install and before the type check.

## Why

The repo already has a Biome lint config (`biome.json`) and a `lint` script, but CI never ran lint. The `lint` script is `biome check --write` (mutating), which is unsafe for CI, so this uses `biome ci .` — the non-mutating, CI-oriented Biome command.

## How verified

- `pnpm install --frozen-lockfile`
- `pnpm exec biome ci .` — exit 0 (16 pre-existing `noExplicitAny` warnings in test files, non-blocking; no source changes needed)
- `pnpm run test` — passes

No mechanical fixes were required (lint is already green).

Part of the marimo-team engineering-excellence initiative to make existing-but-unenforced quality gates actually run in CI.