### PR TITLE
ci: add autofix.ci

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -1,0 +1,40 @@
+name: autofix.ci # needed to securely identify the workflow
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  autofix:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: ⎔ Setup pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+
+      - name: ⎔ Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: 📥 Install dependencies
+        run: pnpm install --ignore-scripts --frozen-lockfile
+
+      # Applies biome check --write. Unfixable lint errors are CI's job to
+      # report (see the lint step in test.yml); don't let them block uploading
+      # the formatting fixes that did apply.
+      - name: 🧹 Apply lint & format fixes
+        run: pnpm run lint || true
+
+      - uses: autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a # v1.3.4


### PR DESCRIPTION
## What this does

Adds an `autofix.ci` workflow that automatically **pushes** lint/format fixes onto pull requests. When a contributor opens or updates a PR, the workflow runs the repo's mutating fixer (`pnpm run lint`, i.e. `biome check --write`) and, via the [autofix.ci](https://autofix.ci) GitHub App, commits any resulting fixes straight back onto the PR branch. Contributors never see a red formatting/lint check they have to reproduce and fix by hand.

The autofix.ci GitHub App is **installed org-wide** for marimo-team (confirmed by an org admin), so this works as soon as it merges — no per-repo setup required.

## How it composes with the existing lint gate

CI's `biome ci .` lint step stays exactly as-is: it's non-mutating and still fails the build on anything that can't be auto-fixed (genuine lint errors are meant to be surfaced, not silently rewritten). autofix.ci is the complement — it handles the *mechanical* fixes (formatting, safe lint autofixes) so that class of failure disappears from the contributor's plate. The fixer step is guarded with `|| true` so unfixable lint errors don't block uploading the fixes that *did* apply; CI remains the source of truth for reporting them.

The setup steps (checkout / pnpm / Node) mirror `test.yml` exactly, with the same SHA-pinned action versions.

## Verification

- Cloned, `pnpm install --ignore-scripts --frozen-lockfile`, ran `pnpm run lint` → **no diff** (tree stays clean; only pre-existing non-fixable warnings, which CI already reports).
- Workflow YAML parses cleanly and passes `actionlint`.
- Workflow `name` is exactly `autofix.ci` (required — the service identifies the workflow by name for security) and the `autofix-ci/action` step runs last.

Part of the marimo-team engineering-excellence initiative.
