### PR TITLE
docs: add AGENTS.md with CLAUDE.md symlink

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+# codemirror-mcp
+
+CodeMirror 6 extension implementing the Model Context Protocol for `@resource` mention and `/prompt` command completions. Published to npm as `@marimo-team/codemirror-mcp` and used by marimo's editor.
+
+## Development
+
+```bash
+pnpm install --ignore-scripts --frozen-lockfile  # CI install
+pnpm test              # vitest
+pnpm run lint          # biome check --write (autofix.ci runs this on PRs)
+pnpm exec biome ci .   # non-mutating lint CI enforces
+pnpm run typecheck     # tsc --noEmit
+pnpm run demo          # vite build of demo/
+```
+
+- Install with `--ignore-scripts`: the `prepare` script otherwise runs `husky install && pnpm build` on every install.
+- Release: `pnpm run release` (pnpm version) bumps + tags; pushing a `v*` tag triggers release.yml, which publishes to npm via OIDC.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
This adds a minimal AGENTS.md as the canonical agent-context doc, with CLAUDE.md as a symlink to it so both the AGENTS.md and CLAUDE.md tool ecosystems resolve the same file. The content is deliberately minimal — a one-line overview plus verified development commands — since these files load into every agent context, so every line is a recurring token cost. Part of the marimo-team engineering-excellence initiative to give agents accurate, low-overhead repo context.